### PR TITLE
Refactored param-expansion and quote-removal

### DIFF
--- a/includes/defines.h
+++ b/includes/defines.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   defines.h                                          :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: znichola <znichola@student.42lausanne.ch>  +#+  +:+       +#+        */
+/*   By: skoulen <skoulen@student.42lausanne.ch>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/16 12:40:00 by znichola          #+#    #+#             */
-/*   Updated: 2023/01/20 17:33:14 by znichola         ###   ########.fr       */
+/*   Updated: 2023/01/29 16:21:23 by skoulen          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -25,7 +25,13 @@
 # define STOP -1
 # define SYNTAX_ERROR -2
 
+/* used in expansion */
 # define T_IFS " 	\n"
+
+/* used in expansion */
+#define MSH_DQUOTE	1U
+#define MSH_SQUOTE	2U
+#define MSH_ESCAPED	4U
 
 /* colours, used in shout builtin */
 

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -6,7 +6,7 @@
 /*   By: skoulen <skoulen@student.42lausanne.ch>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/11 12:31:34 by znichola          #+#    #+#             */
-/*   Updated: 2023/01/29 14:16:50 by skoulen          ###   ########.fr       */
+/*   Updated: 2023/01/29 18:39:17 by skoulen          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -128,7 +128,6 @@ int			expand_cmd(t_cmd *definitive, t_parsed_cmd *intermediate, t_env *env, int 
 /* quote_removal.c */
 
 char		*quote_removal(char *str);
-char		*quote_removal2(char *str);
 
 /* param_expansion */
 

--- a/srcs/expansion/expansion2.c
+++ b/srcs/expansion/expansion2.c
@@ -6,7 +6,7 @@
 /*   By: skoulen <skoulen@student.42lausanne.ch>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/24 11:19:53 by skoulen           #+#    #+#             */
-/*   Updated: 2023/01/29 16:13:38 by skoulen          ###   ########.fr       */
+/*   Updated: 2023/01/29 18:39:06 by skoulen          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -70,7 +70,7 @@ int	expand_redirs(t_list *redirs, t_env *env, int retn)
 		redir = current->content;
 		if (redir->modifier == e_heredoc)
 		{
-			redir->word = quote_removal2(redir->word);
+			redir->word = quote_removal(redir->word);
 		}
 		else
 		{
@@ -130,7 +130,7 @@ static void	remove_all_quotes(t_list *lst)
 	current = lst;
 	while (current)
 	{
-		tmp = quote_removal2(current->content);
+		tmp = quote_removal(current->content);
 		free(current->content);
 		current->content = tmp;
 		current = current->next;

--- a/srcs/expansion/expansion_utils.c
+++ b/srcs/expansion/expansion_utils.c
@@ -6,7 +6,7 @@
 /*   By: skoulen <skoulen@student.42lausanne.ch>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/29 12:59:11 by skoulen           #+#    #+#             */
-/*   Updated: 2023/01/29 19:33:25 by skoulen          ###   ########.fr       */
+/*   Updated: 2023/01/29 22:15:09 by znichola         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -89,14 +89,14 @@ static int	needs_escaping(char c, int state)
 	Escape double-quotes, dollar-signs and backslashes.
 	A backslash is placed before each of these characters.
 
-	Result is malloc()-ed.
+	Result is x_malloc()-ed.
 */
 char	*escape_special_chars(char *str)
 {
 	int		i;
 	char	*res;
 
-	res = x_malloc(1, 2 * ft_strlen(str) + 1);
+	res = x_malloc(sizeof(char), 2 * ft_strlen(str) + 1);
 	i = 0;
 	while (*str)
 	{

--- a/srcs/expansion/expansion_utils.c
+++ b/srcs/expansion/expansion_utils.c
@@ -6,7 +6,7 @@
 /*   By: skoulen <skoulen@student.42lausanne.ch>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/29 12:59:11 by skoulen           #+#    #+#             */
-/*   Updated: 2023/01/29 16:20:28 by skoulen          ###   ########.fr       */
+/*   Updated: 2023/01/29 19:33:25 by skoulen          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,9 +24,11 @@ static int	needs_escaping(char c, int state);
 
 	The state is a single integer containing information about whether we
 	are in a single-quoted state, a double-quoted state, a backslash-escaped
-	state.
-	The operations are done using bitwise operations, since the states can be
-	represented using 3 bits.
+	state, using bitmasks:
+
+	MSH_ESCAPED tells us if we're in a backslash-escaped state
+	MSH_SQUOTE tells us if we're in a single-quoted state
+	MSH_DQUOTE tells us if we're in a double-quoted state
 
 	& is used to check a bit,
 	^= is used to flip a bit,
@@ -70,8 +72,10 @@ int	update_state(char *c, int *state)
 }
 
 /*
-	Checks whether the character would need to be escaped in the
-	given state.
+	Checks if, in the given state, this character would need to be escaped.
+
+	Ex1: In a normal state, the character `a' doesn't need to be escaped.
+	Ex2: In a double-quoted state, the character `$' would need to be escaped.
 */
 static int	needs_escaping(char c, int state)
 {
@@ -85,7 +89,7 @@ static int	needs_escaping(char c, int state)
 	Escape double-quotes, dollar-signs and backslashes.
 	A backslash is placed before each of these characters.
 
-	Result is heap-allocated.
+	Result is malloc()-ed.
 */
 char	*escape_special_chars(char *str)
 {

--- a/srcs/expansion/expansion_utils.c
+++ b/srcs/expansion/expansion_utils.c
@@ -6,15 +6,11 @@
 /*   By: skoulen <skoulen@student.42lausanne.ch>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/29 12:59:11 by skoulen           #+#    #+#             */
-/*   Updated: 2023/01/29 16:03:21 by skoulen          ###   ########.fr       */
+/*   Updated: 2023/01/29 16:20:28 by skoulen          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
-
-#define MSH_DQUOTE	1U
-#define MSH_SQUOTE	2U
-#define MSH_ESCAPED	4U
 
 static int	needs_escaping(char c, int state);
 

--- a/srcs/expansion/param_expansion.c
+++ b/srcs/expansion/param_expansion.c
@@ -6,163 +6,73 @@
 /*   By: skoulen <skoulen@student.42lausanne.ch>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/20 12:52:48 by znichola          #+#    #+#             */
-/*   Updated: 2023/01/29 15:52:57 by skoulen          ###   ########.fr       */
+/*   Updated: 2023/01/29 18:27:31 by skoulen          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
-static void	next_word(t_list *word, char **str, t_env *env, int retn);
-static void	next_chunk(t_list *word, char **str, t_env *env, int retn);
-static int	get_bare_word(char **str, char **ret);
-static int	get_single_q_word(char **str, char **ret);
-static int	get_double_q_word(char **str, char **ret, t_env *env, int retn);
-static int	get_env_variable(char **str, char **ret, t_env *env, int retn);
-// static int	get_tilde_variable(char **str, char **ret, t_env *env);
+static void	insert_value(char **buf, char *val, int pos, int extra_space);
+static void	dollar_expansion(char **str, char **ret, t_env *env, int retn);
+static void	expand_special_param(char **str, char **ret, int retn);
+static void	expand_variable(char **str, char **ret, t_env *env);
 
 /*
-	expand env parameter, replace $VAR $? $~
-	cleans up after it's self, mallocs new return string
- */
+	Perform parameter expansion.
+	We keep track of a state while iterating over the string.
+	If the current character is an unescaped dollar-sign, we insert the
+	corresponding value into the buffer.
+	Else, we update the state and insert the character into the buffer.
+*/
 char	*param_expansion(char *str, t_env *env, int retn)
 {
-	t_list	*words;
-	t_list	*tmp;
-	char	*ret;
-
-	(void)next_word;
-	words = NULL;
-	while (str && *str)
-	{
-		tmp = ft_lstnew(NULL);
-		next_chunk(tmp, &str, env, retn);
-		ft_lstadd_back(&words, tmp);
-	}
-	ret = list_to_str(words);
-	ft_lstclear(&words, free);
-	return(ret);
-}
-
-/*
-	looks for the next "word" / chunk
-	 1 check single quote   start '  stop at ' \0
-	 2 check double quote   start "  stop at " \0
-	 3 check var param      start $  stop at $ ? ~ " '
-	 4 check tilde          start ~  only do ~
-	 5 check bare word    letters    stop at " ' $ \0 ~
-	these function the str in ret and advance str
- */
-static void	next_word(t_list *word, char **str, t_env *env, int retn)
-{
-	char	*ret;
-
-	if (get_single_q_word(str, &ret))
-		;
-	else if (get_double_q_word(str, &ret, env, retn))
-		;
-	else if (get_env_variable(str, &ret, env, retn))
-		;
-	else
-		get_bare_word(str, &ret);
-	word->content = ret;
-}
-
-static void	next_chunk(t_list *word, char **str, t_env *env, int retn)
-{
-	char	*ret;
-
-	if ((*str)[0] == '\\' && (*str)[1] == '$')
-	{
-		(*str)++;
-		get_bare_word(str, &ret);
-	}
-	else if ((*str)[0] == '\'')
-	{
-		get_single_q_word(str, &ret);
-	}
-	else if ((*str)[0] == '"')
-	{
-		get_double_q_word(str, &ret, env, retn);
-	}
-	else if ((*str)[0] == '$')
-	{
-		get_env_variable(str, &ret, env, retn);
-	}
-	else
-	{
-		get_bare_word(str, &ret);
-	}
-	word->content = ret;
-}
-
-/*
-	check single quote   start '  stop at ' \0
-	return 1 on sucess and ret is filled with malloced string
- */
-static int	get_single_q_word(char **str, char **ret)
-{
+	int		state;
+	char	*val;
+	char	*res;
 	int		i;
 
-	i = 1;
-	if ((*str)[0] == '\0' || **str != SINGLE_QUOTE)
-		return (0);
-	while ((*str)[i] && !ft_strchr("\'", (*str)[i]))
-		i++;
-	if (i == 0)
-		return (0);
-	if ((*str)[i] == SINGLE_QUOTE)
-		i++;
-	*ret = ft_substr(*str, 0, i);
-	*str += i;
-	return (1);
-}
-
-/*
-	check double quote   start "  stop at " \0
-	return 1 on sucess and ret is filled with malloced string
- */
-static int	get_double_q_word(char **str, char **ret, t_env *env, int retn)
-{
-	int		i;
-	char	*s1;
-	char	*s2;
-	int		esc;
-
-	esc = 0;
-	i = 1;
-	if ((*str)[0] == '\0' || (**str != DOUBLE_QUOTE))
-		return (0);
-	s1 = ft_strdup("");
-	while ((*str)[i] && ft_strchr("\"", (*str)[i]) == NULL)
+	state = 0;
+	res = x_malloc(1, ft_strlen(str) + 1);
+	i = 0;
+	while (*str)
 	{
-		if ((*str)[i] == '$' && !esc)
+		if (*str == '$' && !(state & MSH_ESCAPED) && !(state & MSH_SQUOTE))
 		{
-			s1 = ft_strmerge(s1, ft_substr(*str, 0, i));
-			*str += i;
-			i = 0;
-			if (get_env_variable(str, &s2, env, retn))
-				s1 = ft_strmerge(s1, s2);
-		}
-		else if ((*str)[i] == '\\' && !esc)
-		{
-			esc = 1;
-			i++;
+			dollar_expansion(&str, &val, env, retn);
+			insert_value(&res, val, i, ft_strlen(str) + 1);
+			i += ft_strlen(val);
 		}
 		else
 		{
-			esc = 0;
-			i++;
+			update_state(str, &state);
+			res[i++] = *(str++);
 		}
 	}
-	if ((*str)[i] == DOUBLE_QUOTE)
-		i++;
-	*ret = ft_strmerge(s1, ft_substr(*str, 0, i));
-	*str += i;
-	return (1);
+	res[i] = 0;
+	return (res);
 }
 
 /*
-	Try $-sign expansion.
+	Helper function for param_expansion2: insert value into the buffer at a
+	given position.
+	Buffer is re-allocated to contain the original contents of the buffer,
+	the value and extra_space.
+*/
+static void	insert_value(char **buf, char *val, int pos, int extra_space)
+{
+	int		len;
+	char	*tmp;
+
+	(*buf)[pos] = 0;
+	len = ft_strlen(*buf) + ft_strlen(val) + extra_space;
+	tmp = x_malloc(1, len);
+	ft_strlcpy(tmp, *buf, len);
+	ft_strlcat(tmp, val, len);
+	*buf = tmp;
+}
+
+/*
+	Perform $-sign expansion.
 	Return 0 if string doesn't start with $-sign.
 	Return 1 if yes and perform $-sign expansion as follows:
 
@@ -180,33 +90,42 @@ static int	get_double_q_word(char **str, char **ret, t_env *env, int retn)
 
 	ret is filled with a heap-allocated result of the expansion.
 */
-static int	get_env_variable(char **str, char **ret, t_env *env, int retn)
+static void	dollar_expansion(char **str, char **ret, t_env *env, int retn)
 {
-	int		i;
-	char	*key;
-	char	*value;
+	if ((*str)[1] && ft_strchr("?!@*#", (*str)[1]))
+	{
+		expand_special_param(str, ret, retn);
+	}
+	else
+	{
+		expand_variable(str, ret, env);
+	}
+}
 
-	if ((*str)[0] != '$')
-		return (0);
-	i = 1;
+static void	expand_special_param(char **str, char **ret, int retn)
+{
 	if ((*str)[1] == '?')
 	{
 		*ret = ft_itoa(retn);
-		*str += 2;
-		return (1);
 	}
-	if (ft_isdigit((*str)[1]) || ((*str)[i] && ft_strchr("!@*", (*str)[1])))
+	if (ft_isdigit((*str)[1]) || ((*str)[1] && ft_strchr("!@*", (*str)[1])))
 	{
 		*ret = ft_strdup("");
-		*str += 2;
-		return (1);
 	}
 	if ((*str)[1] == '#')
 	{
 		*ret = ft_strdup("0");
-		*str += 2;
-		return (1);
 	}
+	*str += 2;
+}
+
+static void	expand_variable(char **str, char **ret, t_env *env)
+{
+	char	*key;
+	char	*value;
+	int		i;
+
+	i = 1;
 	while (ft_isalnum((*str)[i]) || (*str)[i] == '_')
 		i++;
 	key = ft_substr(*str, 1, i - 1);
@@ -214,42 +133,4 @@ static int	get_env_variable(char **str, char **ret, t_env *env, int retn)
 	free(key);
 	*str += i;
 	*ret = escape_special_chars(value);
-	return (1);
-}
-
-// /*
-// 	check tilde          start ~  only do ~
-// 	return 1 on sucess and ret is filled with malloced string
-//  */
-// static int	get_tilde_variable(char **str, char **ret, t_env *env)
-// {
-// 	char	*tmp;
-
-// 	if ((*str)[0] == '\0' || (*str)[0] != '~')
-// 		return (0);
-// 	tmp = ret_env_key(env, "HOME");
-// 	*str += 1;
-// 	if (tmp == NULL)
-// 		return (0);
-// 	*ret = ft_strdup(tmp);
-// 	return (1);
-// }
-
-
-/*
-	check bare word    letters    stop at " ' $ \0 ~
-	return 1 on sucess and ret is filled with malloced string
- */
-static int	get_bare_word(char **str, char **ret)
-{
-	int		i;
-
-	i = 0;
-	while ((*str)[i] && (i == 0 || !ft_strchr("\'\"$\\", (*str)[i])))
-		i++;
-	if (i == 0)
-		return (0);
-	*ret = ft_substr(*str, 0, i);
-	*str += i;
-	return (1);
 }

--- a/srcs/expansion/quote_removal.c
+++ b/srcs/expansion/quote_removal.c
@@ -6,52 +6,26 @@
 /*   By: skoulen <skoulen@student.42lausanne.ch>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/18 21:02:44 by znichola          #+#    #+#             */
-/*   Updated: 2023/01/29 13:31:58 by skoulen          ###   ########.fr       */
+/*   Updated: 2023/01/29 18:39:06 by skoulen          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
-//l$USR"a"
-
-static void	next_word(t_list *word, char **str);
-static char	*get_bare_word(char **str);
-static char	*get_single_q_word(char **str);
-static char	*get_double_q_word(char **str);
-
 /*
-	- string expansion steps -
-	remove outside quotes
-	preserve spaces
-	if replacing an env variable remove the extra spaces inbetween the new caracters
- */
+	Remove quotes, repecting escaped sequences.
 
+	Iterate through the string, keeping track of and updating the state:
+	Single-quoted or double-quoted, and whether we are in a
+	backslash-escaped state.
 
-/*
-	remove extra single_quotes quotes from a string
- */
-char	*quote_removal(char *str)
-{
-	t_list	*words;
-	t_list	*tmp;
-	char	*ret;
+	The update_state() function returns true if the character is not to be
+	kept in the string, which can be deduced using the state.
 
-	words = NULL;
-	while (str && *str)
-	{
-		tmp = ft_lstnew(NULL);
-		next_word(tmp, &str);
-		ft_lstadd_back(&words, tmp);
-	}
-	ret = list_to_str(words);
-	ft_lstclear(&words, free);
-	return (ret);
-}
-
-/*
-	Quote removal, repecting escaped sequences.
+	We use that to decide whether or not to add or not the characters from our
+	str argument to the returning string.
 */
-char	*quote_removal2(char *str)
+char	*quote_removal(char *str)
 {
 	int		state;
 	int		i;
@@ -71,100 +45,4 @@ char	*quote_removal2(char *str)
 	}
 	res[i] = 0;
 	return (res);
-}
-
-/*
-	removes the quotes around words and returns the resulting strings
-	also expands $variables inside the quotes.
- */
-static void	next_word(t_list *word, char **str)
-{
-	char	*s1;
-	char	*s2;
-
-	s1 = get_bare_word(str);
-	if (**str == SINGLE_QUOTE || **str == '\0')
-		s2 = get_single_q_word(str);
-	else
-		s2 = get_double_q_word(str);
-	word->content = (char *)ft_strjoin(s1, s2);
-	free(s1);
-	free(s2);
-}
-
-
-static char	*get_bare_word(char **str)
-{
-	int		i;
-	char	*ret;
-
-	i = 0;
-	while ((*str)[i] && (*str)[i] != SINGLE_QUOTE && (*str)[i] != DOUBLE_QUOTE)
-		i++;
-
-	ret = ft_substr(*str, 0, i);
-	*str += i;
-	return (ret);
-}
-
-static char	*get_single_q_word(char **str)
-{
-	int		i;
-	char	*ret;
-
-	i = 1;
-	if ((*str)[0] == '\0')
-		return (ft_substr(*str, 0, 0));
-	while ((*str)[i])
-	{
-		if ((*str)[i] == SINGLE_QUOTE)
-		{
-			ret = ft_substr(*str, 1, i  - 1);
-			*str += i + 1;
-			return (ret);
-		}
-		i++;
-	}
-	ret = ft_substr(*str, 1, i);
-	*str += i;
-	return (ret);
-}
-
-/*
-	This stage we remove the double quotes
-	Variables in double quotes don't produce two words!
- */
-static char	*get_double_q_word(char **str)
-{
-	int		i;
-	char	*ret;
-	// char	*s1;
-	// char	*s2;
-
-	i = 1;
-	if ((*str)[0] == '\0')
-		return (ft_substr(*str, 0, 0));
-	while ((*str)[i])
-	{
-		if ((*str)[i] == DOUBLE_QUOTE)
-		{
-			ret = ft_substr(*str, 1, i  - 1);
-			*str += i + 1;
-			return (ret);
-		}
-		// if ((*str)[i] == '$')
-		// {
-		// 	s1 = ft_substr(*str, 1, i  - 1);
-		// 	*str += i;
-		// 	s2 = get_env_variable(str, env);
-		// 	ret =ft_strjoin(s1, s2);
-		// 	free(s1);
-		// 	free(s2);
-		// 	return (ret);
-		// }
-		i++;
-	}
-	ret = ft_substr(*str, 1, i);
-	*str += i;
-	return (ret);
 }

--- a/unit-tests-builtins/Makefile
+++ b/unit-tests-builtins/Makefile
@@ -17,8 +17,8 @@ CFLAGS	= -Wall -Wextra
 #CFLAGS += -Werror
 CFLAGS += -g3 -fsanitize=address
 
-TEST_NAMES	=	echo pwd env export
-DEV_NAMES	=
+TEST_NAMES	=	echo pwd env
+DEV_NAMES	=	exprt
 
 # put the unit test files here
 # have one file that's the same as the test name
@@ -56,7 +56,7 @@ fclean : clean
 # Individual unit tests
 $(BIN_PATH)%.test: $(OBJS_PATH)%_test.o libminishell
 	@mkdir -p bin
-	$(CC) $(CFLAGS) -I$(INCS_PATH) -lreadline -lminishell -L.. -o $@ $<
+	$(CC) $(CFLAGS) $< -I$(INCS_PATH) -lreadline -lminishell -L.. -o $@
 
 echo: $(BIN_PATH)echo.test
 

--- a/unit-tests/srcs/param_expansion_test.c
+++ b/unit-tests/srcs/param_expansion_test.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   param_expansion_test.c                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: znichola <znichola@student.42lausanne.ch>  +#+  +:+       +#+        */
+/*   By: skoulen <skoulen@student.42lausanne.ch>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/20 14:05:35 by znichola          #+#    #+#             */
-/*   Updated: 2023/01/26 09:05:26 by znichola         ###   ########.fr       */
+/*   Updated: 2023/01/29 18:27:31 by skoulen          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 

--- a/unit-tests/srcs/quote_removal_test.c
+++ b/unit-tests/srcs/quote_removal_test.c
@@ -6,7 +6,7 @@
 /*   By: skoulen <skoulen@student.42lausanne.ch>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/18 22:54:24 by znichola          #+#    #+#             */
-/*   Updated: 2023/01/29 13:49:27 by skoulen          ###   ########.fr       */
+/*   Updated: 2023/01/29 18:39:06 by skoulen          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -29,7 +29,7 @@ int	main(int argc, char **argv, char **envp)
 	// strarr_print(env_to_strarr(env));
 	if (argc != 2)
 		return (0);
-	char * str = quote_removal2(argv[1]);
+	char * str = quote_removal(argv[1]);
 	ft_printf("{%s}", str);
 	ft_printf("\n");
 	free(str);


### PR DESCRIPTION
I wrote a function, `int update_state(char *str,  int *state)` (that you can find in expansion_utils.c), that updates the parsing state of the string. That state is an integer, it contains info about whether we're in a single-quoted, double-quoted and/or backslash-escaped state. This is achieved using bitmasks.

This function also returns whether or not the character, given the state, has meaning. That means, whether the character must not be rendered. Ex: the quotes in "hello world" have meaning, the quote in hello\"world however does not have meaning.

It is true that the return value is not obvious from the function name, so i could agree to split this into 2 functions, `int is_meaningless(char *s, int state)` and `void update_state(char *s, int *state)`.

`update_state` is very useful because it allows us to iterate over a string and know whether we should perform variable expansion or not, whether we should remove quotes or not, whether we should split whitespace or not, and can therefore be used all over our project, saving us many lines of redundant code. 